### PR TITLE
Add a custom script to make npm run version work in a monorepo

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -22,7 +22,7 @@
     "make": "npm run build && electron-forge make",
     "publish": "npm run build:safe && electron-forge publish",
     "release": "npm run build:safe && electron-forge publish",
-    "version": "powershell mkdir .git -ea 0 && npm version"
+    "version": "powershell mkdir .git -ea 0 ; npm version"
   },
   "dependencies": {
     "@mdi/font": "^7.4.47",


### PR DESCRIPTION
Now to create a new release, it's `npm run version -- patch`