### PR TITLE
Fix flags Electron, scoreboard persistant et comportement bouton

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest]
+        os: [windows-latest]
     
     steps:
       - name: Checkout code

--- a/node/electron/main.cjs
+++ b/node/electron/main.cjs
@@ -55,19 +55,18 @@ function createWindow() {
 
 
   // Charger l'application
+  mainWindow.removeMenu();
+
   if (isDev) {
     mainWindow.loadURL('http://localhost:5173');
   } else {
     mainWindow.loadFile(getDistPath());
-    mainWindow.removeMenu();
   }
 
   // Gérer la fermeture
   mainWindow.on('closed', () => {
     cleanup();
   });
-
-  mainWindow.removeMenu();
 }
 
 // === NETTOYAGE ===
@@ -233,11 +232,12 @@ function createMatchWindow(matchData) {
     },
   });
 
+  matchWindow.removeMenu();
+
   if (isDev) {
     matchWindow.loadURL(`http://localhost:5173/#/match/${matchId}`);
   } else {
     matchWindow.loadFile(getDistPath(), { hash: `/match/${matchId}` });
-    mainWindow.removeMenu();
   }
 
   openWindows[matchId] = matchWindow;
@@ -285,11 +285,12 @@ function createScoreboardWindow() {
     },
   });
 
+  scoreboardWindow.removeMenu();
+
   if (isDev) {
     scoreboardWindow.loadURL('http://localhost:5173/#/scoreboard');
   } else {
     scoreboardWindow.loadFile(getDistPath(), { hash: '/scoreboard' });
-    scoreboardWindow.removeMenu();
   }
 
   // Envoyer les données initiales si un match est déjà sélectionné
@@ -352,14 +353,15 @@ function createFictiveWindows() {
     }
   });
 
+  controlWindow.removeMenu();
+  displayWindow.removeMenu();
+
   if (isDev) {
     controlWindow.loadURL('http://localhost:5173/#/fictive-control');
     displayWindow.loadURL('http://localhost:5173/#/fictive-display');
   } else {
     controlWindow.loadFile(getDistPath(), { hash: '/fictive-control' });
     displayWindow.loadFile(getDistPath(), { hash: '/fictive-display' });
-    controlWindow.removeMenu();
-    displayWindow.removeMenu();
   }
 
   openWindows[fictiveMatchId] = { controlWindow, displayWindow };

--- a/node/electron/main.cjs
+++ b/node/electron/main.cjs
@@ -11,6 +11,9 @@ const SHARED_PARTITION = `persist:main-${process.pid}`;
 let mainWindow = null;
 let openWindows = {};
 let heartbeatIntervals = new Map();
+let scoreboardWindow = null;
+let currentScoreboardMatchId = null;
+const matchDataCache = {};
 
 // === AUTO-UPDATE ===
 updateElectronApp({
@@ -63,6 +66,8 @@ function createWindow() {
   mainWindow.on('closed', () => {
     cleanup();
   });
+
+  mainWindow.removeMenu();
 }
 
 // === NETTOYAGE ===
@@ -72,6 +77,14 @@ function cleanup() {
   // Nettoyer heartbeats
   heartbeatIntervals.forEach((interval) => clearInterval(interval));
   heartbeatIntervals.clear();
+
+  // Fermer le scoreboard persistant
+  try {
+    if (scoreboardWindow && !scoreboardWindow.isDestroyed()) {
+      scoreboardWindow.close();
+    }
+  } catch (e) { /* ignore */ }
+  scoreboardWindow = null;
 
   // Fermer toutes les fenêtres
   Object.values(openWindows).forEach(window => {
@@ -132,13 +145,69 @@ function setupIpcHandlers() {
     stopHeartbeat(matchId);
   });
 
-
   ipcMain.handle('get-window-info', () => ({
     partition: SHARED_PARTITION,
     pid: process.pid,
     openWindows: Object.keys(openWindows),
     heartbeats: Array.from(heartbeatIntervals.keys())
   }));
+
+  // === SCOREBOARD PERSISTANT ===
+
+  // Ouvrir/focaliser le scoreboard persistant
+  ipcMain.on('open-scoreboard', (event) => {
+    if (!scoreboardWindow || scoreboardWindow.isDestroyed()) {
+      createScoreboardWindow();
+    } else {
+      scoreboardWindow.focus();
+    }
+    broadcastScoreboardStatus();
+  });
+
+  // Définir le match affiché dans le scoreboard persistant
+  ipcMain.on('set-scoreboard-match', (event, matchData) => {
+    currentScoreboardMatchId = matchData.idMatch;
+    matchDataCache[matchData.idMatch] = matchData;
+
+    if (!scoreboardWindow || scoreboardWindow.isDestroyed()) {
+      createScoreboardWindow();
+      // les données seront envoyées après dom-ready dans createScoreboardWindow
+    } else {
+      scoreboardWindow.webContents.send('match-data-update', {
+        matchId: currentScoreboardMatchId,
+        data: matchData,
+        type: 'SET_MATCH',
+        timestamp: Date.now()
+      });
+      scoreboardWindow.focus();
+    }
+    broadcastScoreboardStatus();
+  });
+
+  // Récupérer le statut actuel du scoreboard
+  ipcMain.handle('get-scoreboard-status', () => ({
+    isOpen: !!(scoreboardWindow && !scoreboardWindow.isDestroyed()),
+    currentMatchId: currentScoreboardMatchId
+  }));
+
+  // Informations sur l'app (chemin resources, mode dev) — synchrone
+  ipcMain.on('get-app-info', (event) => {
+    event.returnValue = {
+      isDev,
+      resourcesPath: app.isPackaged ? process.resourcesPath : null
+    };
+  });
+}
+
+// Notifier toutes les fenêtres renderers du changement de statut du scoreboard
+function broadcastScoreboardStatus() {
+  const status = {
+    isOpen: !!(scoreboardWindow && !scoreboardWindow.isDestroyed()),
+    currentMatchId: currentScoreboardMatchId
+  };
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send('scoreboard-status-changed', status);
+  }
 }
 
 // === CRÉATION FENÊTRE DE MATCH ===
@@ -172,6 +241,7 @@ function createMatchWindow(matchData) {
   }
 
   openWindows[matchId] = matchWindow;
+  matchDataCache[matchId] = matchData;
 
   matchWindow.on('closed', () => {
     delete openWindows[matchId];
@@ -180,12 +250,67 @@ function createMatchWindow(matchData) {
 
   matchWindow.webContents.once('dom-ready', () => {
     setTimeout(() => {
+      const dataToSend = matchDataCache[matchId] || matchData;
       matchWindow.webContents.send('match-data-update', {
         matchId: matchId,
-        data: matchData,
+        data: dataToSend,
         type: 'INITIAL_DATA'
       });
-    }, 1000);
+    }, 200);
+  });
+}
+
+// === CRÉATION DU SCOREBOARD PERSISTANT ===
+function createScoreboardWindow() {
+  if (scoreboardWindow && !scoreboardWindow.isDestroyed()) {
+    scoreboardWindow.focus();
+    return;
+  }
+
+  const { width } = screen.getPrimaryDisplay().workAreaSize;
+
+  scoreboardWindow = new BrowserWindow({
+    width: 800,
+    height: 600,
+    x: width - 800,
+    y: 0,
+    parent: mainWindow,
+    modal: false,
+    webPreferences: {
+      preload: getPreloadPath(),
+      contextIsolation: true,
+      enableRemoteModule: false,
+      nodeIntegration: false,
+      partition: SHARED_PARTITION,
+    },
+  });
+
+  if (isDev) {
+    scoreboardWindow.loadURL('http://localhost:5173/#/scoreboard');
+  } else {
+    scoreboardWindow.loadFile(getDistPath(), { hash: '/scoreboard' });
+    scoreboardWindow.removeMenu();
+  }
+
+  // Envoyer les données initiales si un match est déjà sélectionné
+  if (currentScoreboardMatchId && matchDataCache[currentScoreboardMatchId]) {
+    const cachedData = matchDataCache[currentScoreboardMatchId];
+    scoreboardWindow.webContents.once('dom-ready', () => {
+      setTimeout(() => {
+        if (scoreboardWindow && !scoreboardWindow.isDestroyed()) {
+          scoreboardWindow.webContents.send('match-data-update', {
+            matchId: currentScoreboardMatchId,
+            data: cachedData,
+            type: 'INITIAL_DATA'
+          });
+        }
+      }, 300);
+    });
+  }
+
+  scoreboardWindow.on('closed', () => {
+    scoreboardWindow = null;
+    broadcastScoreboardStatus();
   });
 }
 
@@ -271,9 +396,22 @@ function closeFictiveWindows() {
 function broadcastMatchUpdate(matchData) {
   const matchId = matchData.idMatch;
 
-  // Envoyer à la fenêtre de match
+  // Mettre à jour le cache
+  matchDataCache[matchId] = matchData;
+
+  // Envoyer à la fenêtre de match spécifique
   if (openWindows[matchId] && !openWindows[matchId].isDestroyed()) {
     openWindows[matchId].webContents.send('match-data-update', {
+      matchId: matchId,
+      data: matchData,
+      type: 'UPDATE',
+      timestamp: Date.now()
+    });
+  }
+
+  // Envoyer au scoreboard persistant si ce match est actuellement affiché
+  if (scoreboardWindow && !scoreboardWindow.isDestroyed() && currentScoreboardMatchId === matchId) {
+    scoreboardWindow.webContents.send('match-data-update', {
       matchId: matchId,
       data: matchData,
       type: 'UPDATE',
@@ -298,6 +436,11 @@ function broadcastMatchUpdate(matchData) {
 }
 
 async function requestMatchData(matchId) {
+  // Vérifier le cache en premier (réponse immédiate)
+  if (matchDataCache[matchId]) {
+    return matchDataCache[matchId];
+  }
+
   if (!mainWindow || mainWindow.isDestroyed()) {
     return null;
   }

--- a/node/electron/preload.js
+++ b/node/electron/preload.js
@@ -20,7 +20,6 @@ contextBridge.exposeInMainWorld("electron", {
   appInfo: appInfo,
 
   // === SCOREBOARD PERSISTANT ===
-  openScoreboard: () => ipcRenderer.send('open-scoreboard'),
   setScoreboardMatch: (matchData) => ipcRenderer.send('set-scoreboard-match', matchData),
   getScoreboardStatus: () => ipcRenderer.invoke('get-scoreboard-status'),
   onScoreboardStatusChanged: (callback) => {

--- a/node/electron/preload.js
+++ b/node/electron/preload.js
@@ -1,10 +1,32 @@
 const { contextBridge, ipcRenderer } = require("electron");
 
+// Récupérer les infos de l'app de façon synchrone (pour countryFlags.js)
+const appInfo = (() => {
+  try {
+    return ipcRenderer.sendSync('get-app-info');
+  } catch (e) {
+    return { isDev: true, resourcesPath: null };
+  }
+})();
+
 contextBridge.exposeInMainWorld("electron", {
   // === MÉTHODES ORIGINALES ===
   openMatchWindow: (matchData) => ipcRenderer.send("open-match-window", matchData),
   openFictiveMatchWindow: () => ipcRenderer.send("open-fictive-match-window"),
   closeFictiveWindows: () => ipcRenderer.send("close-fictive-windows"),
+
+  // === INFORMATIONS APP ===
+  appInfo: appInfo,
+
+  // === SCOREBOARD PERSISTANT ===
+  openScoreboard: () => ipcRenderer.send('open-scoreboard'),
+  setScoreboardMatch: (matchData) => ipcRenderer.send('set-scoreboard-match', matchData),
+  getScoreboardStatus: () => ipcRenderer.invoke('get-scoreboard-status'),
+  onScoreboardStatusChanged: (callback) => {
+    const handler = (event, data) => callback(data);
+    ipcRenderer.on('scoreboard-status-changed', handler);
+    return () => ipcRenderer.removeListener('scoreboard-status-changed', handler);
+  },
   
   // === SYSTÈME DE COMMUNICATION MATCH DATA ===
   

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nippon-kempo-tournament",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nippon-kempo-tournament",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "dependencies": {
         "@mdi/font": "^7.4.47",
         "@mdi/js": "^7.4.47",

--- a/node/package.json
+++ b/node/package.json
@@ -4,7 +4,7 @@
     "name": "Christophe, Florian, Marius et Pierre"
   },
   "description": "Nippon Kempo Tournament Management Application",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "electron/main.cjs",
   "private": true,
   "type": "module",

--- a/node/src/components/Bracket/MatchCard.vue
+++ b/node/src/components/Bracket/MatchCard.vue
@@ -64,11 +64,11 @@
     <!-- bouton scoreboard (Electron seulement, match non terminé) -->
     <div v-if="isElectron && !isDisabled" class="scoreboard-btn-wrapper">
       <VaTooltip placement="top" :text="scoreboardBtnTooltip">
-        <button class="card-scoreboard-btn"
-          :class="{ 'active': scoreboardStatus.currentMatchId === match.idMatch && scoreboardStatus.isOpen }"
-          @click.stop="handleSendToScoreboard($event)">
-          <va-icon name="monitor" size="14px" />
-        </button>
+        <VaButton
+          :class="{ 'scoreboard-active': scoreboardStatus.currentMatchId === match.idMatch && scoreboardStatus.isOpen }"
+          @click.stop="handleSendToScoreboard($event)"
+          preset="secondary" size="small" round icon="tv"
+        />
       </VaTooltip>
     </div>
 
@@ -442,28 +442,8 @@ const scoreboardBtnTooltip = computed(() => {
   margin-top: 4px;
 }
 
-.card-scoreboard-btn {
-  background: transparent;
-  border: 1px solid #ccc;
-  border-radius: 5px;
-  cursor: pointer;
-  padding: 2px 5px;
-  display: flex;
-  align-items: center;
-  opacity: 0.45;
-  transition: opacity 0.2s, background 0.2s;
-}
-
-.card-scoreboard-btn:hover {
-  opacity: 1;
-  background: #e8f0ff;
-}
-
-.card-scoreboard-btn.active {
-  opacity: 1;
-  background: #d4edda;
-  border-color: #22c55e;
-  color: #16a34a;
+.scoreboard-active {
+  color: #16a34a !important;
 }
 
 /* style du chrono */

--- a/node/src/components/Bracket/MatchCard.vue
+++ b/node/src/components/Bracket/MatchCard.vue
@@ -61,6 +61,17 @@
       </template>
     </VaModal>
 
+    <!-- bouton scoreboard (Electron seulement, match non terminé) -->
+    <div v-if="isElectron && !isDisabled" class="scoreboard-btn-wrapper">
+      <VaTooltip placement="top" :text="scoreboardBtnTooltip">
+        <button class="card-scoreboard-btn"
+          :class="{ 'active': scoreboardStatus.currentMatchId === match.idMatch && scoreboardStatus.isOpen }"
+          @click.stop="handleSendToScoreboard($event)">
+          <va-icon name="monitor" size="14px" />
+        </button>
+      </VaTooltip>
+    </div>
+
     <!--  match (uniquement si le match est actif) -->
     <MatchModal v-if="isModalOpen" :matchId="match.idMatch" @close="closeMatchModal" @update="refreshBracket" />
   </div>
@@ -72,6 +83,10 @@ import MatchModal from "../MatchModal.vue";
 import { nationality } from "@/replicache/models/constants"
 import ParticipantDetails from "../ParticipantDetails.vue";
 import { useCountryFlags } from "@/utils/countryFlags";
+import { useScoreboardStatus } from "@/composables/useScoreboardStatus";
+
+const { scoreboardStatus, sendMatchToScoreboard } = useScoreboardStatus();
+const isElectron = !!window.electron;
 
 const props = defineProps({
   match: {
@@ -179,6 +194,27 @@ const getCountry = (natId) => {
 };
 
 const { getFlag } = useCountryFlags();
+
+async function handleSendToScoreboard(event) {
+  event.stopPropagation();
+  if (!window.electron) return;
+
+  const matchData = {
+    ...props.match,
+    player1Data: props.match.player1 || null,
+    player2Data: props.match.player2 || null,
+    timestamp: Date.now()
+  };
+
+  await sendMatchToScoreboard(matchData);
+}
+
+const scoreboardBtnTooltip = computed(() => {
+  const { isOpen, currentMatchId } = scoreboardStatus.value;
+  if (!isOpen) return 'Envoyer ce combat au scoreboard';
+  if (currentMatchId === props.match.idMatch) return 'Ce combat est déjà dans le scoreboard';
+  return 'Remplacer le combat dans le scoreboard';
+});
 
 </script>
 
@@ -398,6 +434,36 @@ const { getFlag } = useCountryFlags();
 /* llignement des Keikokus pour le joueur du bas */
 .player:last-child .keikoku {
   align-self: flex-start;
+}
+
+.scoreboard-btn-wrapper {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 4px;
+}
+
+.card-scoreboard-btn {
+  background: transparent;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  cursor: pointer;
+  padding: 2px 5px;
+  display: flex;
+  align-items: center;
+  opacity: 0.45;
+  transition: opacity 0.2s, background 0.2s;
+}
+
+.card-scoreboard-btn:hover {
+  opacity: 1;
+  background: #e8f0ff;
+}
+
+.card-scoreboard-btn.active {
+  opacity: 1;
+  background: #d4edda;
+  border-color: #22c55e;
+  color: #16a34a;
 }
 
 /* style du chrono */

--- a/node/src/components/MatchModal.vue
+++ b/node/src/components/MatchModal.vue
@@ -6,9 +6,12 @@
       <!-- entête -->
       <div class="header">
         <h1>Gestion du combat</h1>
-        <button class="scoreboard-btn" @click="openScoreboard">
-          <va-icon name="scoreboard" size="40px" title="Ouvrir le scoreboard du match." />
-        </button>
+        <VaTooltip v-if="isElectron" placement="bottom" :text="scoreboardTooltipText">
+          <button class="scoreboard-btn" @click="openScoreboard">
+            <va-icon name="monitor" size="32px" />
+            <span class="scoreboard-indicator" :class="scoreboardIndicatorClass"></span>
+          </button>
+        </VaTooltip>
       </div>
 
       <!-- combattants -->
@@ -178,10 +181,14 @@ import { nationality } from '@/replicache/models/constants';
 import { getParticipantById } from '@/replicache/stores/participantStore';
 import { replicacheInstance as rep } from '@/replicache/replicache';
 import { useCountryFlags } from '@/utils/countryFlags';
+import { useScoreboardStatus } from '@/composables/useScoreboardStatus';
 import { useToast } from "vuestic-ui";
 
 const { getFlag } = useCountryFlags();
 const toast = useToast();
+const { scoreboardStatus, sendMatchToScoreboard } = useScoreboardStatus();
+
+const isElectron = !!window.electron;
 
 const props = defineProps({
   matchId: { type: String, required: true },
@@ -453,28 +460,38 @@ const handleModalValueUpdate = (value) => {
   if (!value) closeModal();
 };
 
-const openScoreboard = () => {
-  if (window.electron && window.electron.openMatchWindow) {
-    try {
-      const rawMatchData = {
-        ...match.value,
-        ipponsPlayer1: ipponsPlayer1.value,
-        ipponsPlayer2: ipponsPlayer2.value,
-        keikokusPlayer1: keikokusPlayer1.value,
-        keikokusPlayer2: keikokusPlayer2.value,
-        player1Data: player1.value,
-        player2Data: player2.value,
-        timestamp: Date.now()
-      };
-      
-      // Nettoyer les données avant transmission
-      const matchData = cleanDataForTransmission(rawMatchData);
-      
-      console.log('🚀 Opening scoreboard with cleaned data:', matchData);
-      window.electron.openMatchWindow(matchData);
-    } catch (error) {
-      console.error('❌ Error opening scoreboard:', error);
-    }
+// Computed pour l'indicateur visuel du bouton scoreboard
+const scoreboardIndicatorClass = computed(() => {
+  const { isOpen, currentMatchId } = scoreboardStatus.value;
+  if (!isOpen) return 'indicator-closed';
+  if (currentMatchId === props.matchId) return 'indicator-this-match';
+  return 'indicator-other-match';
+});
+
+const scoreboardTooltipText = computed(() => {
+  const { isOpen, currentMatchId } = scoreboardStatus.value;
+  if (!isOpen) return 'Ouvrir le scoreboard pour ce combat';
+  if (currentMatchId === props.matchId) return 'Scoreboard actif sur ce combat';
+  return 'Scoreboard actif sur un autre combat — cliquer pour remplacer';
+});
+
+const openScoreboard = async () => {
+  if (!window.electron) return;
+  try {
+    const rawMatchData = {
+      ...match.value,
+      ipponsPlayer1: ipponsPlayer1.value,
+      ipponsPlayer2: ipponsPlayer2.value,
+      keikokusPlayer1: keikokusPlayer1.value,
+      keikokusPlayer2: keikokusPlayer2.value,
+      player1Data: player1.value,
+      player2Data: player2.value,
+      timestamp: Date.now()
+    };
+    const matchData = cleanDataForTransmission(rawMatchData);
+    await sendMatchToScoreboard(matchData);
+  } catch (error) {
+    console.error('❌ Error opening scoreboard:', error);
   }
 };
 
@@ -714,10 +731,35 @@ watch(() => match.value?.timer, (newTimer, oldTimer) => {
 }
 
 .scoreboard-btn {
-  background: transparent;
-  border: none;
+  background: #f0f4ff;
+  border: 2px solid #d0d8f0;
+  border-radius: 10px;
   cursor: pointer;
+  padding: 6px 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  opacity: 1;
+  transition: background 0.2s, border-color 0.2s;
+  position: relative;
 }
+
+.scoreboard-btn:hover {
+  background: #dce6ff;
+  border-color: #99aadd;
+}
+
+.scoreboard-indicator {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.indicator-closed { background: #aaa; }
+.indicator-this-match { background: #22c55e; box-shadow: 0 0 6px #22c55e; }
+.indicator-other-match { background: #f59e0b; box-shadow: 0 0 6px #f59e0b; }
 
 .confirmation-container {
   text-align: center;

--- a/node/src/components/MatchModal.vue
+++ b/node/src/components/MatchModal.vue
@@ -7,10 +7,12 @@
       <div class="header">
         <h1>Gestion du combat</h1>
         <VaTooltip v-if="isElectron" placement="bottom" :text="scoreboardTooltipText">
-          <button class="scoreboard-btn" @click="openScoreboard">
-            <va-icon name="monitor" size="32px" />
-            <span class="scoreboard-indicator" :class="scoreboardIndicatorClass"></span>
-          </button>
+          <VaButton
+            @click="openScoreboard"
+            preset="secondary"
+            icon="tv"
+            :color="scoreboardBtnColor"
+          />
         </VaTooltip>
       </div>
 
@@ -460,19 +462,19 @@ const handleModalValueUpdate = (value) => {
   if (!value) closeModal();
 };
 
-// Computed pour l'indicateur visuel du bouton scoreboard
-const scoreboardIndicatorClass = computed(() => {
+// Couleur du bouton scoreboard selon l'état
+const scoreboardBtnColor = computed(() => {
   const { isOpen, currentMatchId } = scoreboardStatus.value;
-  if (!isOpen) return 'indicator-closed';
-  if (currentMatchId === props.matchId) return 'indicator-this-match';
-  return 'indicator-other-match';
+  if (!isOpen) return 'secondary';
+  if (currentMatchId === props.matchId) return 'success';
+  return 'warning';
 });
 
 const scoreboardTooltipText = computed(() => {
   const { isOpen, currentMatchId } = scoreboardStatus.value;
   if (!isOpen) return 'Ouvrir le scoreboard pour ce combat';
   if (currentMatchId === props.matchId) return 'Scoreboard actif sur ce combat';
-  return 'Scoreboard actif sur un autre combat — cliquer pour remplacer';
+  return 'Scoreboard actif sur un autre combat, cliquer pour remplacer';
 });
 
 const openScoreboard = async () => {
@@ -730,36 +732,6 @@ watch(() => match.value?.timer, (newTimer, oldTimer) => {
   margin-bottom: 16px;
 }
 
-.scoreboard-btn {
-  background: #f0f4ff;
-  border: 2px solid #d0d8f0;
-  border-radius: 10px;
-  cursor: pointer;
-  padding: 6px 10px;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  opacity: 1;
-  transition: background 0.2s, border-color 0.2s;
-  position: relative;
-}
-
-.scoreboard-btn:hover {
-  background: #dce6ff;
-  border-color: #99aadd;
-}
-
-.scoreboard-indicator {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  display: inline-block;
-  flex-shrink: 0;
-}
-
-.indicator-closed { background: #aaa; }
-.indicator-this-match { background: #22c55e; box-shadow: 0 0 6px #22c55e; }
-.indicator-other-match { background: #f59e0b; box-shadow: 0 0 6px #f59e0b; }
 
 .confirmation-container {
   text-align: center;

--- a/node/src/components/Pool/Pool.vue
+++ b/node/src/components/Pool/Pool.vue
@@ -122,6 +122,13 @@
             <!-- entete du match -->
             <div class="match-header">
               Match
+              <VaTooltip v-if="isElectron && !match.idWinner" placement="top" :text="scoreboardBtnTooltip(match)">
+                <button class="match-scoreboard-btn"
+                  :class="{ 'active': scoreboardStatus.currentMatchId === match.idMatch && scoreboardStatus.isOpen }"
+                  @click.stop="handleSendToScoreboard(match, $event)">
+                  <va-icon name="monitor" size="16px" />
+                </button>
+              </VaTooltip>
             </div>
 
             <!-- corps du match -->
@@ -190,6 +197,10 @@ import { determinePoolRanking } from "@/functions/determinePoolRanking"
 import ParticipantDetails from "../ParticipantDetails.vue"
 import { matchService } from '@/replicache/services/matchService';
 import { useCountryFlags } from '@/utils/countryFlags';
+import { useScoreboardStatus } from '@/composables/useScoreboardStatus';
+
+const { scoreboardStatus, sendMatchToScoreboard } = useScoreboardStatus();
+const isElectron = !!window.electron;
 
 // def props
 const props = defineProps({
@@ -418,6 +429,32 @@ function editMatch(match) {
   emit('edit-match', match);
 }
 
+// Envoyer un match au scoreboard persistant
+async function handleSendToScoreboard(match, event) {
+  event.stopPropagation();
+  if (!window.electron) return;
+
+  const p1 = props.pool.participants.find(p => p.id === match.idPlayer1);
+  const p2 = props.pool.participants.find(p => p.id === match.idPlayer2);
+
+  const matchData = {
+    ...match,
+    player1Data: p1 || null,
+    player2Data: p2 || null,
+    timestamp: Date.now()
+  };
+
+  await sendMatchToScoreboard(matchData);
+}
+
+// Tooltip du bouton scoreboard pour un match donné
+function scoreboardBtnTooltip(match) {
+  const { isOpen, currentMatchId } = scoreboardStatus.value;
+  if (!isOpen) return 'Envoyer ce combat au scoreboard';
+  if (currentMatchId === match.idMatch) return 'Ce combat est déjà dans le scoreboard';
+  return 'Remplacer le combat dans le scoreboard';
+}
+
 // fonction recup initials d'un participant
 function getInitials(participant) {
   if (!participant) return '';
@@ -591,6 +628,34 @@ function getCompletedMatchCount() {
   margin-bottom: 12px;
   color: #333;
   text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.match-scoreboard-btn {
+  background: transparent;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  cursor: pointer;
+  padding: 2px 5px;
+  display: flex;
+  align-items: center;
+  opacity: 0.5;
+  transition: opacity 0.2s, background 0.2s;
+}
+
+.match-scoreboard-btn:hover {
+  opacity: 1;
+  background: #e8f0ff;
+}
+
+.match-scoreboard-btn.active {
+  opacity: 1;
+  background: #d4edda;
+  border-color: #22c55e;
+  color: #16a34a;
 }
 
 /* corps du match, utilisation de css grid pour une structure fixe */

--- a/node/src/components/Pool/Pool.vue
+++ b/node/src/components/Pool/Pool.vue
@@ -123,11 +123,11 @@
             <div class="match-header">
               Match
               <VaTooltip v-if="isElectron && !match.idWinner" placement="top" :text="scoreboardBtnTooltip(match)">
-                <button class="match-scoreboard-btn"
-                  :class="{ 'active': scoreboardStatus.currentMatchId === match.idMatch && scoreboardStatus.isOpen }"
-                  @click.stop="handleSendToScoreboard(match, $event)">
-                  <va-icon name="monitor" size="16px" />
-                </button>
+                <VaButton
+                  :class="{ 'scoreboard-active': scoreboardStatus.currentMatchId === match.idMatch && scoreboardStatus.isOpen }"
+                  @click.stop="handleSendToScoreboard(match, $event)"
+                  preset="secondary" size="small" round icon="tv"
+                />
               </VaTooltip>
             </div>
 
@@ -634,28 +634,8 @@ function getCompletedMatchCount() {
   gap: 8px;
 }
 
-.match-scoreboard-btn {
-  background: transparent;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  cursor: pointer;
-  padding: 2px 5px;
-  display: flex;
-  align-items: center;
-  opacity: 0.5;
-  transition: opacity 0.2s, background 0.2s;
-}
-
-.match-scoreboard-btn:hover {
-  opacity: 1;
-  background: #e8f0ff;
-}
-
-.match-scoreboard-btn.active {
-  opacity: 1;
-  background: #d4edda;
-  border-color: #22c55e;
-  color: #16a34a;
+.scoreboard-active {
+  color: #16a34a !important;
 }
 
 /* corps du match, utilisation de css grid pour une structure fixe */

--- a/node/src/composables/useScoreboardStatus.js
+++ b/node/src/composables/useScoreboardStatus.js
@@ -1,0 +1,50 @@
+import { ref } from 'vue';
+
+// Singleton partagé entre tous les composants
+const status = ref({ isOpen: false, currentMatchId: null });
+let initialized = false;
+
+export function useScoreboardStatus() {
+  if (!initialized && window.electron?.getScoreboardStatus) {
+    initialized = true;
+
+    // Récupérer le statut initial
+    window.electron.getScoreboardStatus().then(s => {
+      if (s) status.value = s;
+    });
+
+    // S'abonner aux changements (pas de cleanup car singleton lifetime)
+    window.electron.onScoreboardStatusChanged(s => {
+      status.value = s;
+    });
+  }
+
+  /**
+   * Envoie un match au scoreboard persistant.
+   * Affiche une confirmation si un autre match est déjà en cours.
+   * @param {object} matchData - données du match à envoyer
+   * @returns {Promise<boolean>} true si envoyé, false si annulé
+   */
+  const sendMatchToScoreboard = async (matchData) => {
+    if (!window.electron) return false;
+
+    const currentId = status.value.currentMatchId;
+    const newId = matchData.idMatch;
+
+    if (currentId && currentId !== newId && status.value.isOpen) {
+      // Un autre match est déjà dans le scoreboard → confirmation
+      const confirmed = window.confirm(
+        'Le scoreboard affiche déjà un autre combat.\nVoulez-vous le remplacer par celui-ci ?'
+      );
+      if (!confirmed) return false;
+    }
+
+    window.electron.setScoreboardMatch(matchData);
+    return true;
+  };
+
+  return {
+    scoreboardStatus: status,
+    sendMatchToScoreboard,
+  };
+}

--- a/node/src/router/index.js
+++ b/node/src/router/index.js
@@ -4,6 +4,7 @@ import HomePage from '../views/HomePage.vue';
 import TournamentEditPage from '../views/TournamentEditPage.vue';
 import TournamentManagePage from '../views/TournamentManagePage.vue';
 import MatchScoreboardPage from '../views/MatchScoreboardPage.vue';
+import ScoreboardPage from '../views/ScoreboardPage.vue';
 import MatchScoreboardFictifPage from '@/views/MatchScoreboardFictifPage.vue';
 import MatchScoreboardFictifAdminPage from '@/views/MatchScoreboardFictifAdminPage.vue';
 
@@ -23,6 +24,7 @@ const router = createRouter({
     { path: "/tournament/non-started/:id", component: TournamentEditPage },
     { path: "/tournament/started/:id", component: TournamentManagePage },
     { path: "/match/:id", component: MatchScoreboardPage },
+    { path: "/scoreboard", component: ScoreboardPage },
     {
       path: '/fictive-control',
       component: MatchScoreboardFictifAdminPage

--- a/node/src/utils/countryFlags.js
+++ b/node/src/utils/countryFlags.js
@@ -4,6 +4,13 @@ export function useCountryFlags() {
       return '';
     }
     const isoCode = country.isoAlpha2.toLowerCase();
+
+    // En production Electron, construire le chemin absolu via file://
+    const info = window.electron?.appInfo;
+    if (info && !info.isDev && info.resourcesPath) {
+      return `file://${info.resourcesPath}/dist/flags/${isoCode}.svg`;
+    }
+
     return `./flags/${isoCode}.svg`;
   };
 

--- a/node/src/views/ScoreboardPage.vue
+++ b/node/src/views/ScoreboardPage.vue
@@ -9,49 +9,26 @@
 
   <!-- Scoreboard actif -->
   <div v-else class="scoreboard">
-    <!-- Ligne 1 : Joueur 1, fond rouge -->
-    <div class="scoreboard-row row-red">
+    <!-- Lignes des joueurs -->
+    <div v-for="p in playersData" :key="p.num" :class="['scoreboard-row', p.colorClass]">
       <div class="row-content">
         <div class="flag">
           <div class="flag-placeholder">
-            <div v-if="!isFlag1Loaded" class="spinner"></div>
+            <div v-if="!flagsLoaded[p.num]" class="spinner"></div>
           </div>
-          <img v-show="isFlag1Loaded" @load="isFlag1Loaded = true" :src="getFlag(player1Nationality)"
-            alt="Drapeau Joueur 1" />
+          <img v-show="flagsLoaded[p.num]" @load="onFlagLoad(p.num)" :src="getFlag(p.nationality)"
+            :alt="'Drapeau Joueur ' + p.num" />
         </div>
         <div class="player-info">
           <div class="player-name">
-            {{ player1 ? player1.firstName + ' ' + player1.lastName : 'En attente' }}
+            {{ p.player ? p.player.firstName + ' ' + p.player.lastName : 'En attente' }}
           </div>
-          <div class="club-name">{{ player1?.clubName || '' }}</div>
+          <div class="club-name">{{ p.player?.clubName || '' }}</div>
         </div>
       </div>
       <div class="score-info">
-        <div class="ippons">{{ match ? match.ipponsPlayer1 : 0 }}</div>
-        <div class="keikokus-player-1">{{ match ? match.keikokusPlayer1 : 0 }}</div>
-      </div>
-    </div>
-
-    <!-- Ligne 2 : Joueur 2, fond blanc -->
-    <div class="scoreboard-row row-white">
-      <div class="row-content">
-        <div class="flag">
-          <div class="flag-placeholder">
-            <div v-if="!isFlag2Loaded" class="spinner"></div>
-          </div>
-          <img v-show="isFlag2Loaded" @load="isFlag2Loaded = true" :src="getFlag(player2Nationality)"
-            alt="Drapeau Joueur 2" />
-        </div>
-        <div class="player-info">
-          <div class="player-name">
-            {{ player2 ? player2.firstName + ' ' + player2.lastName : 'En attente' }}
-          </div>
-          <div class="club-name">{{ player2?.clubName || '' }}</div>
-        </div>
-      </div>
-      <div class="score-info">
-        <div class="ippons">{{ match ? match.ipponsPlayer2 : 0 }}</div>
-        <div class="keikokus-player-2">{{ match ? match.keikokusPlayer2 : 0 }}</div>
+        <div class="ippons">{{ p.ippons }}</div>
+        <div :class="['keikokus', p.keikokuClass]">{{ p.keikokus }}</div>
       </div>
     </div>
 
@@ -83,8 +60,8 @@ const match = ref(null);
 const player1 = ref(null);
 const player2 = ref(null);
 const isWaiting = ref(true);
-const isFlag1Loaded = ref(false);
-const isFlag2Loaded = ref(false);
+const flagsLoaded = ref({ 1: false, 2: false });
+const onFlagLoad = (num) => { flagsLoaded.value[num] = true; };
 
 let updateCleanup;
 
@@ -94,6 +71,23 @@ const getCountry = (natId) => nationality.find(c => c.id === Number(natId));
 
 const player1Nationality = computed(() => getCountry(player1.value?.nationalityId));
 const player2Nationality = computed(() => getCountry(player2.value?.nationalityId));
+
+const playersData = computed(() => {
+  const players = {
+    1: { color: 'row-red', player: player1.value, nationality: player1Nationality.value },
+    2: { color: 'row-white', player: player2.value, nationality: player2Nationality.value }
+  };
+  
+  return [1, 2].map(num => ({
+    num,
+    colorClass: players[num].color,
+    keikokuClass: `keikokus-player-${num}`,
+    player: players[num].player,
+    nationality: players[num].nationality,
+    ippons: match.value ? match.value[`ipponsPlayer${num}`] : 0,
+    keikokus: match.value ? match.value[`keikokusPlayer${num}`] : 0,
+  }));
+});
 
 const progressPercent = computed(() => {
   if (!match.value?.timer) return 0;
@@ -124,8 +118,7 @@ const handleMatchUpdate = (updateData) => {
 
   // Si nouveau match (matchId différent), réinitialiser les drapeaux
   if (match.value && match.value.idMatch !== data.idMatch) {
-    isFlag1Loaded.value = false;
-    isFlag2Loaded.value = false;
+    flagsLoaded.value = { 1: false, 2: false };
   }
 
   match.value = data;
@@ -383,21 +376,19 @@ watch(
   font-weight: bold;
 }
 
-.keikokus-player-1 {
+.keikokus {
   flex: 0;
   display: flex;
-  align-items: flex-end;
   margin-bottom: 10px;
   justify-content: flex-end;
   font-size: clamp(2rem, 6vw, 10rem);
 }
 
+.keikokus-player-1 {
+  align-items: flex-end;
+}
+
 .keikokus-player-2 {
-  flex: 0;
-  display: flex;
   align-items: flex-start;
-  margin-bottom: 10px;
-  justify-content: flex-end;
-  font-size: clamp(2rem, 6vw, 10rem);
 }
 </style>

--- a/node/src/views/ScoreboardPage.vue
+++ b/node/src/views/ScoreboardPage.vue
@@ -1,0 +1,403 @@
+<template>
+  <!-- Écran d'attente -->
+  <div v-if="isWaiting" class="waiting-screen">
+    <div class="waiting-content">
+      <img src="../assets/img/scoreboard_nippon_img.png" alt="Nippon Kempo" class="waiting-logo" />
+      <h2 class="waiting-text">En attente d'un combat...</h2>
+    </div>
+  </div>
+
+  <!-- Scoreboard actif -->
+  <div v-else class="scoreboard">
+    <!-- Ligne 1 : Joueur 1, fond rouge -->
+    <div class="scoreboard-row row-red">
+      <div class="row-content">
+        <div class="flag">
+          <div class="flag-placeholder">
+            <div v-if="!isFlag1Loaded" class="spinner"></div>
+          </div>
+          <img v-show="isFlag1Loaded" @load="isFlag1Loaded = true" :src="getFlag(player1Nationality)"
+            alt="Drapeau Joueur 1" />
+        </div>
+        <div class="player-info">
+          <div class="player-name">
+            {{ player1 ? player1.firstName + ' ' + player1.lastName : 'En attente' }}
+          </div>
+          <div class="club-name">{{ player1?.clubName || '' }}</div>
+        </div>
+      </div>
+      <div class="score-info">
+        <div class="ippons">{{ match ? match.ipponsPlayer1 : 0 }}</div>
+        <div class="keikokus-player-1">{{ match ? match.keikokusPlayer1 : 0 }}</div>
+      </div>
+    </div>
+
+    <!-- Ligne 2 : Joueur 2, fond blanc -->
+    <div class="scoreboard-row row-white">
+      <div class="row-content">
+        <div class="flag">
+          <div class="flag-placeholder">
+            <div v-if="!isFlag2Loaded" class="spinner"></div>
+          </div>
+          <img v-show="isFlag2Loaded" @load="isFlag2Loaded = true" :src="getFlag(player2Nationality)"
+            alt="Drapeau Joueur 2" />
+        </div>
+        <div class="player-info">
+          <div class="player-name">
+            {{ player2 ? player2.firstName + ' ' + player2.lastName : 'En attente' }}
+          </div>
+          <div class="club-name">{{ player2?.clubName || '' }}</div>
+        </div>
+      </div>
+      <div class="score-info">
+        <div class="ippons">{{ match ? match.ipponsPlayer2 : 0 }}</div>
+        <div class="keikokus-player-2">{{ match ? match.keikokusPlayer2 : 0 }}</div>
+      </div>
+    </div>
+
+    <!-- Ligne 3 : fond noir -->
+    <div class="scoreboard-row row-black">
+      <div class="nippon-img-container">
+        <img src="../assets/img/scoreboard_nippon_img.png" alt="Scoreboard Nippon" class="scoreboard-nippon-img" />
+      </div>
+      <div class="other-content">
+        <div class="chrono-display">
+          <va-progress-circle :model-value="progressPercent" :indeterminate="match?.timer?.isRunning" color="#ffffff"
+            class="timer-progress-circle" :thickness="0.2" />
+          <span class="time-text">{{ displayedTime }}</span>
+        </div>
+        <div class="time-label">
+          {{ match?.timer?.currentTime > 0 ? 'Temps réglementaire' : (match?.timer?.additionalTime > -1 ? 'Temps additionnel' : '') }}
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
+import { nationality } from '@/replicache/models/constants';
+import { useCountryFlags } from '@/utils/countryFlags';
+
+const match = ref(null);
+const player1 = ref(null);
+const player2 = ref(null);
+const isWaiting = ref(true);
+const isFlag1Loaded = ref(false);
+const isFlag2Loaded = ref(false);
+
+let updateCleanup;
+
+const { getFlag } = useCountryFlags();
+
+const getCountry = (natId) => nationality.find(c => c.id === Number(natId));
+
+const player1Nationality = computed(() => getCountry(player1.value?.nationalityId));
+const player2Nationality = computed(() => getCountry(player2.value?.nationalityId));
+
+const progressPercent = computed(() => {
+  if (!match.value?.timer) return 0;
+  let currentTime = match.value.timer.currentTime;
+  let total = 180;
+  if (currentTime === 0 && match.value.timer.additionalTime > -1) {
+    currentTime = match.value.timer.additionalTime;
+    total = 60;
+  }
+  return (currentTime / total) * 100;
+});
+
+const displayedTime = computed(() => {
+  if (!match.value?.timer) return '00:00';
+  let time = match.value.timer.currentTime;
+  if (time === 0 && match.value.timer.additionalTime > -1) {
+    time = match.value.timer.additionalTime;
+  }
+  const minutes = Math.floor(time / 60);
+  const seconds = time % 60;
+  return `${minutes.toString().padStart(1, '0')}:${seconds.toString().padStart(2, '0')}`;
+});
+
+const handleMatchUpdate = (updateData) => {
+  if (!updateData?.data) return;
+
+  const { data } = updateData;
+
+  // Si nouveau match (matchId différent), réinitialiser les drapeaux
+  if (match.value && match.value.idMatch !== data.idMatch) {
+    isFlag1Loaded.value = false;
+    isFlag2Loaded.value = false;
+  }
+
+  match.value = data;
+
+  if (data.player1Data) player1.value = data.player1Data;
+  if (data.player2Data) player2.value = data.player2Data;
+
+  isWaiting.value = false;
+};
+
+const gongSound = new Audio('./finalSound.ogg');
+
+onMounted(async () => {
+  if (!window.electron) return;
+
+  // S'abonner aux mises à jour
+  updateCleanup = window.electron.onMatchDataUpdate(handleMatchUpdate);
+
+  // Vérifier si un match est déjà sélectionné dans le scoreboard
+  const status = await window.electron.getScoreboardStatus();
+  if (status?.currentMatchId) {
+    const cached = await window.electron.requestMatchData(status.currentMatchId);
+    if (cached) {
+      handleMatchUpdate({ data: cached });
+    }
+  }
+});
+
+onUnmounted(() => {
+  if (updateCleanup) updateCleanup();
+});
+
+// Détecter la fin du temps et jouer le gong
+watch(
+  () => ({
+    currentTime: match.value?.timer?.currentTime,
+    additionalTime: match.value?.timer?.additionalTime,
+  }),
+  (newVal, oldVal) => {
+    if (oldVal?.currentTime > 0 && newVal.currentTime === 0 &&
+        (newVal.additionalTime === undefined || newVal.additionalTime === -1)) {
+      gongSound.play().catch(() => {});
+    }
+  }
+);
+</script>
+
+<style scoped>
+@font-face {
+  font-family: 'Bebas Neue';
+  src: url('/fonts/BebasNeue-Regular.ttf') format('truetype');
+  font-weight: normal;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'DS-Digital';
+  src: url('/fonts/DS-Digital.woff2') format('woff2'),
+       url('/fonts/DS-Digital.woff') format('woff');
+  font-weight: normal;
+  font-style: normal;
+  font-display: swap;
+}
+
+/* Écran d'attente */
+.waiting-screen {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  background: #0a0a1a;
+}
+
+.waiting-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+}
+
+.waiting-logo {
+  width: 300px;
+  opacity: 0.85;
+  animation: pulse 2.5s ease-in-out infinite;
+}
+
+.waiting-text {
+  color: #ffffff;
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: clamp(1.5rem, 4vw, 3rem);
+  letter-spacing: 4px;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 0.5; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.03); }
+}
+
+/* Scoreboard */
+.scoreboard {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  min-height: 0;
+}
+
+.scoreboard-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex: 1 1 0;
+  min-height: 0;
+  padding: 10px;
+}
+
+.row-red { background-color: red; color: black; }
+.row-white { background-color: white; color: black; }
+.row-black { background-color: black; color: white; }
+
+.scoreboard-row.row-black {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.nippon-img-container {
+  flex: 0 0 33.33%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.scoreboard-nippon-img { width: 100%; height: auto; }
+
+.other-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-end;
+  gap: 10px;
+}
+
+.time-label {
+  font-size: clamp(1.2rem, 3vw, 4rem);
+  font-weight: bold;
+  color: white;
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  margin-top: 5px;
+  padding: 5px 10px;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 10px;
+}
+
+.chrono-display {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: clamp(1rem, 12vw, 20rem);
+  font-weight: bold;
+  color: white;
+  padding-right: 20px;
+}
+
+.time-text { font-family: 'DS-Digital', monospace !important; }
+
+.timer-progress-circle {
+  width: clamp(1rem, 10vw, 15rem) !important;
+  height: clamp(1rem, 10vw, 20rem) !important;
+}
+
+.row-content {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 5;
+}
+
+.spinner {
+  width: 30px;
+  height: 30px;
+  border: 3px solid rgba(66, 133, 244, 0.1);
+  border-radius: 50%;
+  border-top-color: #4285f4;
+  animation: spin 1s linear infinite;
+  margin-bottom: 15px;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.flag img {
+  width: 20vw;
+  max-width: 200px;
+  height: auto;
+  border-radius: 20px;
+  margin-right: 30px;
+  margin-left: 20px;
+  border: 1.5px solid black;
+}
+
+.flag-placeholder {
+  width: 20vw;
+  max-width: 200px;
+  height: auto;
+  border-radius: 20px;
+  margin-right: 30px;
+  margin-left: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.player-info {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  flex: 1;
+}
+
+.player-name {
+  font-size: clamp(1.5rem, 5vw, 7rem);
+  font-weight: bold;
+  font-family: 'Bebas Neue', sans-serif;
+}
+
+.club-name {
+  font-size: clamp(1rem, 3vw, 5rem);
+  font-family: 'Bebas Neue', sans-serif;
+}
+
+.score-info {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: stretch;
+  width: 100%;
+  flex: 1;
+  margin-right: 50px;
+}
+
+.ippons {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: clamp(5rem, 15vw, 30rem);
+  font-weight: bold;
+}
+
+.keikokus-player-1 {
+  flex: 0;
+  display: flex;
+  align-items: flex-end;
+  margin-bottom: 10px;
+  justify-content: flex-end;
+  font-size: clamp(2rem, 6vw, 10rem);
+}
+
+.keikokus-player-2 {
+  flex: 0;
+  display: flex;
+  align-items: flex-start;
+  margin-bottom: 10px;
+  justify-content: flex-end;
+  font-size: clamp(2rem, 6vw, 10rem);
+}
+</style>


### PR DESCRIPTION
- Drapeaux : chemin absolu file:// en production Electron via appInfo IPC
- Scoreboard persistant (ScoreboardPage.vue) remplace les fenêtres par match :
  affiche 'en attente' au démarrage, se met à jour dès qu'un match est envoyé
- Données initiales injectées depuis le cache main.cjs (délai réduit 1000ms → 200ms)
- Bouton scoreboard dans MatchModal : indicateur coloré (gris/vert/orange) + tooltip
- Bouton 📺 sur chaque match card (Pool et MatchCard) avec tooltip et confirmation
  si remplacement d'un autre combat en cours
- useScoreboardStatus composable singleton pour le statut réactif partagé