### PR TITLE
Hotfix : double déclaration scoreboardWindow (crash au démarrage)

### DIFF
--- a/node/electron/main.cjs
+++ b/node/electron/main.cjs
@@ -10,7 +10,6 @@ const SHARED_PARTITION = 'persist:nk-tournament';
 // === VARIABLES GLOBALES ===
 let mainWindow = null;
 let openWindows = {};
-let scoreboardWindow = null;
 let heartbeatIntervals = new Map();
 let scoreboardWindow = null;
 let currentScoreboardMatchId = null;


### PR DESCRIPTION
## Problème

L'app crashait au démarrage avec `SyntaxError: Identifier 'scoreboardWindow' has already been declared`.

La variable était déclarée deux fois dans `main.cjs` (lignes 13 et 15) suite au merge silencieux des branches `fix/tournament-bugs` et `fix/scoreboard-flags-minor` : chaque branche avait ajouté sa propre déclaration, git a mergé les deux sans conflit.

## Fix

Suppression de la déclaration en doublon (ligne 13). Une seule déclaration reste à la bonne place.

## Test

- [ ] Lancer l'app buildée en prod → ne doit plus crasher au démarrage